### PR TITLE
Fixed some Documentation

### DIFF
--- a/pywhatkit/mainfunctions.py
+++ b/pywhatkit/mainfunctions.py
@@ -48,8 +48,8 @@ def showHistory():
 
 
 def shutdown(time = 20):
-    """Will shutdown Mac, Windows and Linux Computers
-    For Widnows System, time is given as Seconds and for Mac and Linux Computers
+    """Will shutdown Mac, Windows and Linux Computers.
+    For Windows System, time is given as Seconds and for Mac and Linux Computers
     Time is given as mintues"""
     global osname
     osname = platform.system()

--- a/pywhatkit/mainfunctions.py
+++ b/pywhatkit/mainfunctions.py
@@ -48,8 +48,9 @@ def showHistory():
 
 
 def shutdown(time = 20):
-    """Will shutdown the computer in given seconds
-For Windows, Linux and Mac only"""
+    """Will shutdown Mac, Windows and Linux Computers
+    For Widnows System, time is given as Seconds and for Mac and Linux Computers
+    Time is given as mintues"""
     global osname
     osname = platform.system()
     if "window" in osname.lower():


### PR DESCRIPTION
Shutdown Function in Mac/Linux is different from the Windows one. Windows takes the time in seconds whereas Mac and Linux take the time in minutes. So, the documentation was improved to provide a better insight about the Shutdown Function.

Linux Man Page for [Shutdown](https://linux.die.net/man/8/shutdown)
Mac [Shutdown](https://osxdaily.com/2017/08/13/shutdown-mac-command-line/) command.
