### PR TITLE
Chnage: return info instead of just printing it.

### DIFF
--- a/pywhatkit/main.py
+++ b/pywhatkit/main.py
@@ -152,10 +152,11 @@ def sendwhatmsg_to_group(group_id: str, message: str, time_hour: int, time_min: 
     pg.typewrite(message + "\n")
 
 
-def info(topic: str, lines: int = 3) -> None:
+def info(topic: str, lines: int = 3) -> str:
     # Gives information on the topic
     spe = wikipedia.summary(topic, sentences=lines)
     print(spe)
+    return spe
 
 
 def playonyt(topic: str, use_api: bool = False) -> str:


### PR DESCRIPTION
You should return info as a string instead of just printing it. So it can be used for other purposes too.

Simply return the string from info() instead of just printing it.

So it can be used for other purposes too like using it to have a speech output with text to speech.

A big thank you with this PR.♥
