### PR TITLE
Removing logic to click in middle of screen

### DIFF
--- a/pywhatkit/core/core.py
+++ b/pywhatkit/core/core.py
@@ -75,7 +75,6 @@ def send_message(message: str, receiver: str, wait_time: int) -> None:
 
     _web(receiver=receiver, message=message)
     time.sleep(7)
-    click(WIDTH / 2, HEIGHT / 2 + 15)
     time.sleep(wait_time - 7)
     if not check_number(number=receiver):
         for char in message:


### PR DESCRIPTION
Removing logic to click in middle of screen from 'send_message' function of core.py. Screen is already focused on textbox when WhatsApp is launched. Clicking middle of screen may click away from WhatsApp WebApp, resulting in several issues if window is not centered on screen, including: 

- inability to send message (closes #231)
- inability to type in the appropriate textbox 
- inadvertently clicking on different window/part of window
- sending to incorrect recipient

