### PR TITLE
Fixed ValueError

### DIFF
--- a/pywhatkit/whats.py
+++ b/pywhatkit/whats.py
@@ -96,7 +96,7 @@ def sendwhatmsg_to_group(
 ) -> None:
     """Send WhatsApp Message to a Group at a Certain Time"""
 
-    if time_hour not in range(25) or time_min not in range(60):
+    if time_hour not in range(24) or time_min not in range(60):
         raise Warning("Invalid Time Format!")
 
     current_time = time.localtime()


### PR DESCRIPTION
ValueError: time data '24:0:0' does not match format '%H:%M:%S' - this error should be except in "if time_hour not in range(25)" (x2)

# ⚠ ***IMPORTANT POINTS:*** ⚠

- *Give the PR an appropriate Title.*
- *If you want to fix a lot of Issues together, please consider opening a Draft PR first and mention alL the issues in a list along with the status of the fix that you are working on.*
- *Mention the `IssueNumber` in your PR if it is fixing an Issue with `closes #IssueNumber`.*
- *Please provide sufficient information regarding the changes you have made.*
- *Please read the [CONTRIBUTION](https://github.com/Ankit404butfound/PyWhatKit/blob/master/CONTRIBUTING.md) guidelines first otherwise your PR may not get merged.*

[comment]: <> (Please remove all the above points and this message while creating the PR.)
