### PR TITLE
fixed hanging when importing pywhatkit on Fedora 38 issue was request…

### DIFF
--- a/pywhatkit/core/core.py
+++ b/pywhatkit/core/core.py
@@ -80,7 +80,7 @@ def check_connection() -> None:
     """Check the Internet connection of the Host Machine"""
 
     try:
-        requests.get("https://google.com")
+        requests.get("https://google.com", timeout=5)
     except requests.RequestException:
         raise InternetException(
             "Error while connecting to the Internet. Make sure you are connected to the Internet!"

--- a/pywhatkit/handwriting.py
+++ b/pywhatkit/handwriting.py
@@ -9,7 +9,7 @@ def text_to_handwriting(
     """Convert the given String to Handwritten Characters"""
 
     data = requests.get(
-        f"https://pywhatkit.herokuapp.com/handwriting?text={string}&rgb={rgb[0]},{rgb[1]},{rgb[2]}"
+        f"https://pywhatkit.herokuapp.com/handwriting?text={string}&rgb={rgb[0]},{rgb[1]},{rgb[2]}", timeout=5
     )
     status_code = (
         data.status_code

--- a/pywhatkit/misc.py
+++ b/pywhatkit/misc.py
@@ -53,7 +53,7 @@ def playonyt(topic: str, use_api: bool = False, open_video: bool = True) -> str:
 
     if use_api:
         response = requests.get(
-            f"https://pywhatkit.herokuapp.com/playonyt?topic={topic}"
+            f"https://pywhatkit.herokuapp.com/playonyt?topic={topic}", timeout=5
         )
         status_code = response.status_code
         if status_code == 200:
@@ -67,7 +67,7 @@ def playonyt(topic: str, use_api: bool = False, open_video: bool = True) -> str:
     else:
         url = f"https://www.youtube.com/results?q={topic}"
         count = 0
-        cont = requests.get(url)
+        cont = requests.get(url, timeout=5)
         data = cont.content
         data = str(data)
         lst = data.split('"')


### PR DESCRIPTION
…s.get without timeout. Added 5 seconds timeout to four requests.get in handwriting.py misc.py and core.py

In Fedora 38 Python 3.10 just running import pywhatkit will never complete. After debug the problem was the request.get on check_connection()  in core/core.py. 

The requests line to check for internet connection was: 

```requests.get("https://google.com")```

Changing it to 

```requests.get("https://google.com", timeout=5)```

 fixed the hanging problem.

I did added the timeout to other request.get that I found.

From requests package:


"Timeouts

You can tell Requests to stop waiting for a response after a given number of seconds with the timeout parameter. Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely"

https://requests.readthedocs.io/en/latest/user/quickstart/

This is my first pull request ever so it may not be completely right.

Thank you for this wonderful program, it really help me a lot. 
I'd like to do some more small changes like this in the future.