### PR TITLE
Adding Support For Emoji -- Issue #274

### DIFF
--- a/pywhatkit/core/core.py
+++ b/pywhatkit/core/core.py
@@ -108,11 +108,27 @@ def send_message(message: str, receiver: str, wait_time: int) -> None:
     click(WIDTH / 2, HEIGHT / 2 + 15)
     time.sleep(wait_time - 7)
     if not check_number(number=receiver):
-        for char in message:
-            if char == "\n":
+        index = 0
+        length = len(message)
+        while index < length:
+            letter = message[index]
+            typewrite(letter)
+            print(index, letter)
+            if letter == ":":
+                index += 1
+                while index < length:
+                    letter = message[index]
+                    print(index, letter)
+                    if letter == ":":
+                        press("enter")
+                        break
+                    typewrite(letter)
+                    index += 1
+            elif letter == "\n":
                 hotkey("shift", "enter")
-            else:
-                typewrite(char)
+            index += 1
+        press("enter")
+        
     findtextbox()
     press("enter")
 

--- a/pywhatkit/core/core.py
+++ b/pywhatkit/core/core.py
@@ -113,12 +113,10 @@ def send_message(message: str, receiver: str, wait_time: int) -> None:
         while index < length:
             letter = message[index]
             typewrite(letter)
-            print(index, letter)
             if letter == ":":
                 index += 1
                 while index < length:
                     letter = message[index]
-                    print(index, letter)
                     if letter == ":":
                         press("enter")
                         break

--- a/pywhatkit/core/core.py
+++ b/pywhatkit/core/core.py
@@ -112,8 +112,8 @@ def send_message(message: str, receiver: str, wait_time: int) -> None:
         length = len(message)
         while index < length:
             letter = message[index]
-            typewrite(letter)
-            if letter == ":":
+            if letter == ":":    
+                typewrite(letter)
                 index += 1
                 while index < length:
                     letter = message[index]
@@ -124,6 +124,8 @@ def send_message(message: str, receiver: str, wait_time: int) -> None:
                     index += 1
             elif letter == "\n":
                 hotkey("shift", "enter")
+            else:
+                typewrite(letter)
             index += 1
         press("enter")
         

--- a/pywhatkit/whats.py
+++ b/pywhatkit/whats.py
@@ -37,7 +37,6 @@ def sendwhatmsg_instantly(
     time.sleep(4)
     pg.click(core.WIDTH / 2, core.HEIGHT / 2 + 15)
     time.sleep(wait_time - 4)
-    core.findtextbox()
     pg.press("enter")
     log.log_message(_time=time.localtime(), receiver=phone_no, message=message)
     if tab_close:

--- a/pywhatkit/whats.py
+++ b/pywhatkit/whats.py
@@ -33,10 +33,25 @@ def sendwhatmsg_instantly(
     if not fullmatch(r"^\+?[0-9]{2,4}\s?[0-9]{9,15}", phone_no):
         raise exceptions.InvalidPhoneNumber("Invalid Phone Number.")
 
-    web.open(f"https://web.whatsapp.com/send?phone={phone_no}&text={quote(message)}")
-    time.sleep(4)
-    pg.click(core.WIDTH / 2, core.HEIGHT / 2 + 15)
-    time.sleep(wait_time - 4)
+    web.open(f"https://web.whatsapp.com/send?phone={phone_no}")
+    time.sleep(wait_time)
+    index = 0
+    length = len(message)
+    while index < length:
+        letter = message[index]
+        pg.write(letter)
+        print(index, letter)
+        if letter == ":":
+            index += 1
+            while index < length:
+                letter = message[index]
+                print(index, letter)
+                if letter == ":":
+                    pg.press("enter")
+                    break
+                pg.write(letter)
+                index += 1
+        index += 1
     pg.press("enter")
     log.log_message(_time=time.localtime(), receiver=phone_no, message=message)
     if tab_close:

--- a/pywhatkit/whats.py
+++ b/pywhatkit/whats.py
@@ -40,12 +40,10 @@ def sendwhatmsg_instantly(
     while index < length:
         letter = message[index]
         pg.write(letter)
-        print(index, letter)
         if letter == ":":
             index += 1
             while index < length:
                 letter = message[index]
-                print(index, letter)
                 if letter == ":":
                     pg.press("enter")
                     break


### PR DESCRIPTION
Fixes #274
Adding Support For Emoji -- Issue #274

Any Emoji must be declared between two colons
:salute: --> 🫡
:bicep: --> 💪

Ensure there is an empty space before the first colon

The words to be used for every emoji can be checked here
https://gist.github.com/hkan/264423ab0ee720efb55e05a0f5f90887

Also, Removed Unnecessary Clicking On TextBox While Sending Text Message Immediately Using The Function sendwhatmsg_instantly
