### PR TITLE
sendwhats_image does not attach image and send it

### DIFF
--- a/pywhatkit/core/core.py
+++ b/pywhatkit/core/core.py
@@ -202,10 +202,12 @@ def send_image(path: str, caption: str, receiver: str, wait_time: int) -> None:
                 typewrite(char)
     else:
         typewrite(" ")
+
+    click(WIDTH / 2, HEIGHT / 2 + 15)
     if system().lower() == "darwin":
         hotkey("command", "v")
     else:
         hotkey("ctrl", "v")
     time.sleep(1)
-    findtextbox()
+
     press("enter")


### PR DESCRIPTION
closes #315

The send_image function in the core module already uses the click() function from pygui to find the text box in which the text is getting typed. I have reused the same to find the textbox again before pasting the image. The current implementation was using the findtextbox() method which was internally using pygui to locate an image on screen which it could not find.  

Please let me know if this approach seems right. This has been tested on MacOs with Firefox to be working for me. 

